### PR TITLE
Perf improvements

### DIFF
--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -37,15 +37,12 @@ namespace Slugify
         /// </summary>
         public string GenerateSlug(string inputString)
         {
-            if (_config.TrimWhitespace)
-            {
-                inputString = inputString.Trim();
-            }
+            StringBuilder sb = new StringBuilder();
 
-            if (_config.ForceLowerCase)
-            {
-                inputString = inputString.ToLower();
-            }
+            // First we trim and lowercase if necessary
+            PrepareStringBuilder(inputString, sb);
+
+            inputString = sb.ToString();
 
             inputString = CleanWhiteSpace(inputString);
             inputString = ApplyReplacements(inputString);
@@ -60,6 +57,46 @@ namespace Slugify
             return inputString;
         }
 
+        private void PrepareStringBuilder(string inputString, StringBuilder sb)
+        {
+            bool seenFirstNonWhitespace = false;
+            int indexOfLastNonWhitespace = 0;
+            for (int i = 0; i < inputString.Length; i++)
+            {
+                // first, clean whitepace
+                char c = inputString[i];
+                if (!seenFirstNonWhitespace && char.IsWhiteSpace(c))
+                {
+                    if (_config.TrimWhitespace)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        sb.Append(c);
+                    }
+                }
+                else
+                {
+                    seenFirstNonWhitespace = true;
+                    if (!char.IsWhiteSpace(c))
+                    {
+                        indexOfLastNonWhitespace = sb.Length;
+                    }
+                    if (_config.ForceLowerCase)
+                    {
+                        c = char.ToLower(c);
+                    }
+
+                    sb.Append(c);
+                }
+            }
+
+            if (_config.TrimWhitespace)
+            {
+                sb.Length = indexOfLastNonWhitespace + 1;
+            }
+        }
         protected string CleanWhiteSpace(string str)
         {
             return _cleanWhiteSpaceRegex.Replace(str, " ");

--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -9,6 +9,8 @@ namespace Slugify
 {
     public class SlugHelperImproved : ISlugHelper
     {
+        private static readonly Dictionary<string, Regex> _deleteRegexMap = new Dictionary<string, Regex>();
+
         protected SlugHelper.Config _config { get; set; }
 
         private readonly Regex _deniedCharactersRegex;
@@ -21,7 +23,12 @@ namespace Slugify
         {
             _config = config ?? throw new ArgumentNullException(nameof(config), "can't be null use default config or empty constructor.");
 
-            _deniedCharactersRegex = new Regex(_config.DeniedCharactersRegex, RegexOptions.Compiled);
+            if (!_deleteRegexMap.TryGetValue(_config.DeniedCharactersRegex, out _deniedCharactersRegex))
+            {
+                _deniedCharactersRegex = new Regex(_config.DeniedCharactersRegex, RegexOptions.Compiled);
+                _deleteRegexMap.Add(_config.DeniedCharactersRegex, _deniedCharactersRegex);
+            }
+
             _cleanWhiteSpaceRegex = new Regex(_config.CollapseWhiteSpace ? @"\s+" : @"\s", RegexOptions.Compiled);
             _collapseDashesRegex = new Regex("--+", RegexOptions.Compiled);
         }

--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -108,29 +108,19 @@ namespace Slugify
 
         private void ApplyStringReplacements(StringBuilder sb)
         {
-            bool replaced;
-            do
+            foreach (var replacement in _config.StringReplacements)
             {
-                replaced = false;
-                foreach (var replacement in _config.StringReplacements)
+                for (int i = 0; i < sb.Length; i++)
                 {
-                    for (int i = 0; i < sb.Length; i++)
+                    if (SubstringEquals(sb, i, replacement.Key))
                     {
-                        char c = sb[i];
+                        sb.Remove(i, replacement.Key.Length);
+                        sb.Insert(i, replacement.Value);
 
-                        if (SubstringEquals(sb, i, replacement.Key))
-                        {
-                            sb.Remove(i, replacement.Key.Length);
-                            sb.Insert(i, replacement.Value);
-
-                            i += replacement.Value.Length - 1;
-
-                            replaced = true;
-                        }
+                        i += replacement.Value.Length - 1;
                     }
                 }
             }
-            while (replaced);
         }
 
         private static bool SubstringEquals(StringBuilder sb, int index, string toMatch)
@@ -153,7 +143,7 @@ namespace Slugify
                     return false;
                 }
             }
-            return sb.Length == toMatch.Length;
+            return (sb.Length - index) == toMatch.Length;
         }
 
         // Thanks http://stackoverflow.com/a/249126!

--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -66,7 +66,8 @@ namespace Slugify
             {
                 // first, clean whitepace
                 char c = inputString[i];
-                if (!seenFirstNonWhitespace && char.IsWhiteSpace(c))
+                bool isWhitespace = char.IsWhiteSpace(c);
+                if (!seenFirstNonWhitespace && isWhitespace)
                 {
                     if (_config.TrimWhitespace)
                     {
@@ -80,7 +81,7 @@ namespace Slugify
                 else
                 {
                     seenFirstNonWhitespace = true;
-                    if (!char.IsWhiteSpace(c))
+                    if (!isWhitespace)
                     {
                         indexOfLastNonWhitespace = sb.Length;
                     }

--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -15,7 +15,6 @@ namespace Slugify
         protected SlugHelper.Config _config { get; set; }
 
         private readonly Regex _deniedCharactersRegex;
-        private readonly Regex _cleanWhiteSpaceRegex;
 
         public SlugHelperImproved() : this(_defaultConfig.Value) { }
 
@@ -28,8 +27,6 @@ namespace Slugify
                 _deniedCharactersRegex = new Regex(_config.DeniedCharactersRegex, RegexOptions.Compiled);
                 _deleteRegexMap.Add(_config.DeniedCharactersRegex, _deniedCharactersRegex);
             }
-
-            _cleanWhiteSpaceRegex = new Regex(_config.CollapseWhiteSpace ? @"\s+" : @"\s", RegexOptions.Compiled);
         }
 
         /// <summary>
@@ -44,7 +41,6 @@ namespace Slugify
 
             inputString = sb.ToString();
 
-            inputString = CleanWhiteSpace(inputString);
             inputString = ApplyReplacements(inputString);
             inputString = RemoveDiacritics(inputString);
             inputString = DeleteCharacters(inputString);
@@ -83,6 +79,18 @@ namespace Slugify
                     {
                         indexOfLastNonWhitespace = sb.Length;
                     }
+                    else
+                    {
+                        c = ' ';
+
+                        if (_config.CollapseWhiteSpace)
+                        {
+                            while ((i + 1) < inputString.Length && char.IsWhiteSpace(inputString[i + 1]))
+                            {
+                                i++;
+                            }
+                        }
+                    }
                     if (_config.ForceLowerCase)
                     {
                         c = char.ToLower(c);
@@ -96,10 +104,6 @@ namespace Slugify
             {
                 sb.Length = indexOfLastNonWhitespace + 1;
             }
-        }
-        protected string CleanWhiteSpace(string str)
-        {
-            return _cleanWhiteSpaceRegex.Replace(str, " ");
         }
 
         // Thanks http://stackoverflow.com/a/249126!

--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml;
 
 namespace Slugify
 {
@@ -61,7 +60,6 @@ namespace Slugify
 
             return inputString;
         }
-       
 
         protected string CleanWhiteSpace(string str)
         {
@@ -72,7 +70,7 @@ namespace Slugify
         protected string RemoveDiacritics(string str)
         {
             var stFormD = str.Normalize(NormalizationForm.FormD);
-            
+
             //perf: initialise this with the length of the chars
             var sb = new StringBuilder(stFormD.Length);
 

--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -37,12 +37,12 @@ namespace Slugify
             StringBuilder sb = new StringBuilder();
 
             // First we trim and lowercase if necessary
-            PrepareStringBuilder(inputString, sb);
+            PrepareStringBuilder(inputString.Normalize(NormalizationForm.FormD), sb);
             ApplyStringReplacements(sb);
+            RemoveNonSpacingMarks(sb);
 
             inputString = sb.ToString();
 
-            inputString = RemoveDiacritics(inputString);
             inputString = DeleteCharacters(inputString);
 
             if (_config.CollapseDashes)
@@ -147,23 +147,16 @@ namespace Slugify
         }
 
         // Thanks http://stackoverflow.com/a/249126!
-        protected string RemoveDiacritics(string str)
+        protected void RemoveNonSpacingMarks(StringBuilder sb)
         {
-            var stFormD = str.Normalize(NormalizationForm.FormD);
-
-            //perf: initialise this with the length of the chars
-            var sb = new StringBuilder(stFormD.Length);
-
-            for (var ich = 0; ich < stFormD.Length; ich++)
+            for (var ich = 0; ich < sb.Length; ich++)
             {
-                var uc = CharUnicodeInfo.GetUnicodeCategory(stFormD[ich]);
-                if (uc != UnicodeCategory.NonSpacingMark)
+                if (CharUnicodeInfo.GetUnicodeCategory(sb[ich]) == UnicodeCategory.NonSpacingMark)
                 {
-                    sb.Append(stFormD[ich]);
+                    sb.Remove(ich, 1);
+                    ich--;
                 }
             }
-
-            return sb.ToString().Normalize(NormalizationForm.FormC);
         }
 
         protected string DeleteCharacters(string str)

--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -10,6 +10,7 @@ namespace Slugify
     public class SlugHelperImproved : ISlugHelper
     {
         private static readonly Dictionary<string, Regex> _deleteRegexMap = new Dictionary<string, Regex>();
+        private static readonly Lazy<SlugHelper.Config> _defaultConfig = new Lazy<SlugHelper.Config>(() => new SlugHelper.Config());
 
         protected SlugHelper.Config _config { get; set; }
 
@@ -17,7 +18,7 @@ namespace Slugify
         private readonly Regex _cleanWhiteSpaceRegex;
         private readonly Regex _collapseDashesRegex;
 
-        public SlugHelperImproved() : this(new SlugHelper.Config()) { }
+        public SlugHelperImproved() : this(_defaultConfig.Value) { }
 
         public SlugHelperImproved(SlugHelper.Config config)
         {

--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -8,6 +8,7 @@ namespace Slugify
 {
     public class SlugHelperImproved : ISlugHelper
     {
+        private static readonly Lazy<Regex> _collapseDashesRegex = new Lazy<Regex>(() => new Regex("--+", RegexOptions.Compiled));
         private static readonly Dictionary<string, Regex> _deleteRegexMap = new Dictionary<string, Regex>();
         private static readonly Lazy<SlugHelper.Config> _defaultConfig = new Lazy<SlugHelper.Config>(() => new SlugHelper.Config());
 
@@ -15,7 +16,6 @@ namespace Slugify
 
         private readonly Regex _deniedCharactersRegex;
         private readonly Regex _cleanWhiteSpaceRegex;
-        private readonly Regex _collapseDashesRegex;
 
         public SlugHelperImproved() : this(_defaultConfig.Value) { }
 
@@ -30,7 +30,6 @@ namespace Slugify
             }
 
             _cleanWhiteSpaceRegex = new Regex(_config.CollapseWhiteSpace ? @"\s+" : @"\s", RegexOptions.Compiled);
-            _collapseDashesRegex = new Regex("--+", RegexOptions.Compiled);
         }
 
         /// <summary>
@@ -55,7 +54,7 @@ namespace Slugify
 
             if (_config.CollapseDashes)
             {
-                inputString = _collapseDashesRegex.Replace(inputString, "-");
+                inputString = _collapseDashesRegex.Value.Replace(inputString, "-");
             }
 
             return inputString;

--- a/src/Slugify.Core/SlugHelperImproved.cs
+++ b/src/Slugify.Core/SlugHelperImproved.cs
@@ -8,7 +8,6 @@ namespace Slugify
 {
     public class SlugHelperImproved : ISlugHelper
     {
-        private static readonly Lazy<Regex> _collapseDashesRegex = new Lazy<Regex>(() => new Regex("--+", RegexOptions.Compiled));
         private static readonly Dictionary<string, Regex> _deleteRegexMap = new Dictionary<string, Regex>();
         private static readonly Lazy<SlugHelper.Config> _defaultConfig = new Lazy<SlugHelper.Config>(() => new SlugHelper.Config());
 
@@ -53,10 +52,10 @@ namespace Slugify
  
             if (_config.CollapseDashes)
             {
-                inputString = _collapseDashesRegex.Value.Replace(inputString, "-");
+                CollapseDashes(sb);
             }
 
-            return inputString;
+            return sb.ToString();
         }
 
         private void PrepareStringBuilder(string inputString, StringBuilder sb)
@@ -175,6 +174,31 @@ namespace Slugify
                 {
                     sb.Remove(i, 1);
                     i--;
+                }
+            }
+        }
+
+        protected void CollapseDashes(StringBuilder sb)
+        {
+            bool firstDash = true;
+            for (int i = 0; i < sb.Length; i++)
+            {
+                // first, clean whitepace
+                if (sb[i] == '-')
+                {
+                    if (firstDash)
+                    {
+                        firstDash = false;
+                    }
+                    else
+                    {
+                        sb.Remove(i, 1);
+                        i--;
+                    }
+                }
+                else
+                {
+                    firstDash = true;
                 }
             }
         }

--- a/tests/Slugify.Core.Benchmarks/Program.cs
+++ b/tests/Slugify.Core.Benchmarks/Program.cs
@@ -30,7 +30,11 @@ namespace Slugify.Core.Benchmarks
         {
             for (var i = 0; i < _textList.Count; i++)
             {
-                new SlugHelper().GenerateSlug(_textList[i]);
+                new SlugHelper(new SlugHelper.Config
+                {
+                    // to enable legacy behaviour, for fairness
+                    DeniedCharactersRegex = @"[^a-zA-Z0-9\-\._]"
+                }).GenerateSlug(_textList[i]);
             }
         }
 

--- a/tests/Slugify.Core.Benchmarks/Program.cs
+++ b/tests/Slugify.Core.Benchmarks/Program.cs
@@ -10,22 +10,18 @@ namespace Slugify.Core.Benchmarks
     {
         private static void Main(string[] args)
         {
-            var summary = BenchmarkRunner.Run<SlugifyBenchmarks>();
+            BenchmarkRunner.Run<SlugifyBenchmarks>();
         }
     }
 
     [MemoryDiagnoser]
     public class SlugifyBenchmarks
     {
-        private ISlugHelper _slugHelper;
-        private ISlugHelper _slugHelperImproved;
         private List<string> _textList;
 
         [GlobalSetup]
         public void GlobalSetup()
         {
-            _slugHelper = new SlugHelper();
-            _slugHelperImproved = new SlugHelperImproved();
             _textList = File.ReadAllLines("gistfile.txt").ToList();
         }
 
@@ -34,7 +30,7 @@ namespace Slugify.Core.Benchmarks
         {
             for (var i = 0; i < _textList.Count; i++)
             {
-                _slugHelper.GenerateSlug(_textList[i]);
+                new SlugHelper().GenerateSlug(_textList[i]);
             }
         }
 
@@ -43,7 +39,7 @@ namespace Slugify.Core.Benchmarks
         {
             for (var i = 0; i < _textList.Count; i++)
             {
-                _slugHelperImproved.GenerateSlug(_textList[i]);
+                new SlugHelperImproved().GenerateSlug(_textList[i]);
             }
         }
     }

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -104,6 +104,20 @@ namespace Slugify.Tests
         }
 
         [Fact]
+        public void TestCharacterReplacementWithWhitespace()
+        {
+            const string original = "     abcde     ";
+            const string expected = "bcde";
+
+            var config = new SlugHelper.Config();
+            config.StringReplacements.Add("a", " ");
+
+            var helper = Create(config);
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
+        [Fact]
         public void TestCharacterReplacement()
         {
             const string original = "abcde";

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -134,6 +134,98 @@ namespace Slugify.Tests
             Assert.Equal(expected, helper.GenerateSlug(original));
         }
 
+        [Fact]
+        public void TestCharacterReplacementOrdering()
+        {
+            const string original = "catdogfish";
+            const string expected = "cdf";
+
+            var config = new SlugHelper.Config();
+            config.StringReplacements.Add("cat", "c");
+            config.StringReplacements.Add("catdog", "e");
+            config.StringReplacements.Add("dog", "d");
+            config.StringReplacements.Add("fish", "f");
+
+            var helper = Create(config);
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
+        [Fact]
+        public void TestCharacterReplacementShorting()
+        {
+            const string original = "catdogfish";
+            const string expected = "cdf";
+
+            var config = new SlugHelper.Config();
+            config.StringReplacements.Add("cat", "c");
+            config.StringReplacements.Add("dog", "d");
+            config.StringReplacements.Add("fish", "f");
+
+            var helper = Create(config);
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
+        [Fact]
+        public void TestCharacterReplacementLengthening()
+        {
+            const string original = "a";
+            const string expected = "ccdccdcc";
+
+            var config = new SlugHelper.Config();
+            config.StringReplacements.Add("a", "bdbdb");
+            config.StringReplacements.Add("b", "cc");
+
+            var helper = Create(config);
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
+        [Fact]
+        public void TestCharacterReplacementLookBackwards()
+        {
+            const string original = "cat";
+            const string expected = "at";
+
+            var config = new SlugHelper.Config();
+            config.StringReplacements.Add("a", "c");
+            config.StringReplacements.Add("cc", "a");
+
+            var helper = Create(config);
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
+        [Fact]
+        public void TestRecursiveReplacement()
+        {
+            const string original = "ycdabbadcz";
+            const string expected = "yz";
+
+            var config = new SlugHelper.Config();
+            config.StringReplacements.Add("abba", "");
+            config.StringReplacements.Add("cddc", "");
+
+            var helper = Create(config);
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
+        [Fact]
+        public void TestRecursiveReplacement2()
+        {
+            const string original = "yababbabaz";
+            const string expected = "yabbaz";
+
+            var config = new SlugHelper.Config();
+            config.StringReplacements.Add("abba", "");
+
+            var helper = Create(config);
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
         [Theory]
         [InlineData("E¢Ðƕtoy  mÚÄ´¨ss¨sïuy   !!!!!  Pingüiño", "etoy-muasssiuy-pinguino")]
         [InlineData("QWE dfrewf# $%&!! asd", "qwe-dfrewf-asd")]

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -201,20 +201,6 @@ namespace Slugify.Tests
             Assert.Equal(expected, helper.GenerateSlug(original));
         }
 
-        [Fact(Skip = "This fails, skipping for now, as not sure if it's a real problem")]
-        public void TestConfigForTrimmingWithTrailingReplacedCharacter()
-        {
-            const string original = "  foo & bar  &";
-            const string expected = "foo-bar";
-
-            var helper = Create(new SlugHelper.Config
-            {
-                TrimWhitespace = true
-            });
-
-            Assert.Equal(expected, helper.GenerateSlug(original));
-        }
-
         [Fact]
         public void TestHandlingOfUnicodeCharacters()
         {

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -17,6 +17,19 @@ namespace Slugify.Tests
             Assert.True(config.CollapseWhiteSpace);
             Assert.Single(config.StringReplacements);
             Assert.NotNull(new Regex(config.DeniedCharactersRegex));
+            Assert.Null(config.DeniedCharactersRegex);
+            Assert.NotEmpty(config.AllowedChars);
+        }
+
+        [Fact]
+        public void TestDeniedCharacterConfig()
+        {
+            var config = new SlugHelper.Config
+            {
+                DeniedCharactersRegex = ""
+            };
+
+            Assert.Throws<InvalidOperationException>(() => config.AllowedChars);
         }
 
         [Fact]
@@ -99,6 +112,20 @@ namespace Slugify.Tests
             const string expected = "";
 
             var helper = Create();
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
+        [Fact]
+        public void TestDeniedCharacterDeletionCustomized()
+        {
+            const string original = "ab!#$%&/()=";
+            const string expected = "b$";
+
+            var config = new SlugHelper.Config();
+            config.AllowedChars.Remove('a');
+            config.AllowedChars.Add('$');
+            var helper = Create(config);
 
             Assert.Equal(expected, helper.GenerateSlug(original));
         }

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -119,6 +119,21 @@ namespace Slugify.Tests
             Assert.Equal(expected, helper.GenerateSlug(original));
         }
 
+        [Fact]
+        public void TestCharacterDoubleReplacement()
+        {
+            const string original = "a";
+            const string expected = "c";
+
+            var config = new SlugHelper.Config();
+            config.StringReplacements.Add("a", "b");
+            config.StringReplacements.Add("b", "c");
+
+            var helper = Create(config);
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
         [Theory]
         [InlineData("E¢Ðƕtoy  mÚÄ´¨ss¨sïuy   !!!!!  Pingüiño", "etoy-muasssiuy-pinguino")]
         [InlineData("QWE dfrewf# $%&!! asd", "qwe-dfrewf-asd")]

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using System.Text.RegularExpressions;
 
 namespace Slugify.Tests
 {
@@ -16,7 +15,6 @@ namespace Slugify.Tests
             Assert.True(config.ForceLowerCase);
             Assert.True(config.CollapseWhiteSpace);
             Assert.Single(config.StringReplacements);
-            Assert.NotNull(new Regex(config.DeniedCharactersRegex));
             Assert.Null(config.DeniedCharactersRegex);
             Assert.NotEmpty(config.AllowedChars);
         }
@@ -126,6 +124,21 @@ namespace Slugify.Tests
             config.AllowedChars.Remove('a');
             config.AllowedChars.Add('$');
             var helper = Create(config);
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
+
+        [Fact]
+        public void TestDeniedCharacterDeletionLegacy()
+        {
+            const string original = "!#$%&/()=";
+            const string expected = "";
+
+            var helper = Create(new SlugHelper.Config
+            {
+                DeniedCharactersRegex = @"[^a-zA-Z0-9\-\._]"
+            });
 
             Assert.Equal(expected, helper.GenerateSlug(original));
         }

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -58,7 +58,10 @@ namespace Slugify.Tests
             const string original = "a  b    \n  c   \t    d";
             const string expected = "a-b-c-d";
 
-            var helper = Create();
+            var helper = Create(new SlugHelper.Config
+            {
+                CollapseDashes = false
+            });
 
             Assert.Equal(expected, helper.GenerateSlug(original));
         }
@@ -67,10 +70,11 @@ namespace Slugify.Tests
         public void TestWhiteSpaceNotCollapsing()
         {
             const string original = "a  b    \n  c   \t    d";
-            const string expected = "a-b-c-d";
+            const string expected = "a--b-------c--------d";
 
             var helper = Create(new SlugHelper.Config
             {
+                CollapseDashes = false,
                 CollapseWhiteSpace = false
             });
 


### PR DESCRIPTION
I'm done. Removed all of the regexes, except a backwards compatible mode for people using DeniedCharacters. The rest is (mostly) allocation free. There is more that could be done but I think this is a nice balance where its mostly readable, but also pretty good.

Fully backwards compatible (I think!) and a reasonable improvement IMO.

On my laptop, on battery:

|   Method |      Mean |    Error |   StdDev | Ratio | RatioSD |      Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |----------:|---------:|---------:|------:|--------:|-----------:|------:|------:|----------:|
| Baseline | 116.33 ms | 2.318 ms | 3.095 ms |  1.00 |    0.00 | 22200.0000 |     - |     - |  44.66 MB |
| Improved |  53.87 ms | 1.072 ms | 1.669 ms |  0.46 |    0.02 |  2666.6667 |     - |     - |   5.34 MB |