### PR TITLE
Fixed issue where result was always empty if DeniedCharactersRegex was set.

### DIFF
--- a/src/Slugify.Core/SlugHelper.cs
+++ b/src/Slugify.Core/SlugHelper.cs
@@ -46,8 +46,9 @@ namespace Slugify
                     _deleteRegexMap.Add(Config.DeniedCharactersRegex, deniedCharactersRegex);
                 }
 
+                var currentValue = sb.ToString();
                 sb.Clear();
-                sb.Append(DeleteCharacters(sb.ToString(), deniedCharactersRegex));
+                sb.Append(DeleteCharacters(currentValue, deniedCharactersRegex));
             }
 
             if (Config.CollapseDashes)

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -143,6 +143,21 @@ namespace Slugify.Tests
             Assert.Equal(expected, helper.GenerateSlug(original));
         }
 
+
+        [Fact]
+        public void TestDeniedCharacterDeletionLegacyKeepsAllowedCharacters()
+        {
+            const string original = "Abc-123.$1$_x";
+            const string expected = "abc-123.1_x";
+
+            var helper = Create(new SlugHelperConfiguration
+            {
+                DeniedCharactersRegex = @"[^a-zA-Z0-9\-\._]"
+            });
+
+            Assert.Equal(expected, helper.GenerateSlug(original));
+        }
+
         [Fact]
         public void TestCharacterReplacementWithWhitespace()
         {


### PR DESCRIPTION
The StringBuilder was cleared before the regex was applied. Therefore the result was always an empty string.