### PR TITLE
Fix replacement of umlauts and other diacritics

### DIFF
--- a/src/Slugify.Core/SlugHelper.cs
+++ b/src/Slugify.Core/SlugHelper.cs
@@ -116,14 +116,17 @@ namespace Slugify
         {
             foreach (var replacement in Config.StringReplacements)
             {
+                var search = replacement.Key.Normalize(NormalizationForm.FormD);
+                var replace = replacement.Value.Normalize(NormalizationForm.FormD);
+
                 for (var i = 0; i < sb.Length; i++)
                 {
-                    if (SubstringEquals(sb, i, replacement.Key))
+                    if (SubstringEquals(sb, i, search))
                     {
-                        sb.Remove(i, replacement.Key.Length);
-                        sb.Insert(i, replacement.Value);
+                        sb.Remove(i, search.Length);
+                        sb.Insert(i, replace);
 
-                        i += replacement.Value.Length - 1;
+                        i += replace.Length - 1;
                     }
                 }
             }

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -252,6 +252,42 @@ namespace Slugify.Tests
         }
 
         [Fact]
+        public void TestCharacterReplacementUmlauts()
+        {
+            var config = new SlugHelperConfiguration()
+            {
+                StringReplacements =
+                {
+                    {"Ä", "Ae" },
+                    {"Ö", "Oe" },
+                    {"Ü", "Ue" },
+                    {"ä", "ae" },
+                    {"ö", "oe" },
+                    {"ü", "ue" },
+                    {"ß", "ss" }
+                },
+            };
+
+            var helper = Create(config);
+            Assert.Equal("aeoeueaeoeuess", helper.GenerateSlug("äöüÄÖÜß"));
+        }
+
+        [Fact]
+        public void TestCharacterReplacementDiacritics()
+        {
+            var config = new SlugHelperConfiguration();
+            config.StringReplacements.Add("Å", "AA");
+            config.StringReplacements.Add("å", "aa");
+            config.StringReplacements.Add("Æ", "AE");
+            config.StringReplacements.Add("æ", "ae");
+            config.StringReplacements.Add("Ø", "OE");
+            config.StringReplacements.Add("ø", "oe");
+
+            var helper = Create(config);
+            Assert.Equal("aa-aa-ae-ae-oe-oe", helper.GenerateSlug("Å å Æ æ Ø ø"));
+        }
+
+        [Fact]
         public void TestRecursiveReplacement()
         {
             const string original = "ycdabbadcz";


### PR DESCRIPTION
Normalize the key and value of the string replacement entries to ensure that the configured replacements can be matched in the string after normalization.

Fixes #25
Fixes #21