### PR TITLE
Option to limit Slug Length

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ config.CollapseWhiteSpace = true;
 // Remove everything that's not a letter, number, hyphen, dot, or underscore
 config.DeniedCharactersRegex = @"[^a-zA-Z0-9\-\._]";
 
-// No Character limit to the slug lenght
+// No Character limit to the slug length
 config.MaxLength = null;
 
 // Create a helper instance with our new configuration

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ config.CollapseWhiteSpace = true;
 // Remove everything that's not a letter, number, hyphen, dot, or underscore
 config.DeniedCharactersRegex = @"[^a-zA-Z0-9\-\._]";
 
+// No Character limit to the slug lenght
+config.MaxLength = null;
+
 // Create a helper instance with our new configuration
 SlugHelper helper = new SlugHelper(config);
 ```
@@ -140,6 +143,12 @@ Any character matching this Regular Expression will be deleted from the resultin
 Type: _Boolean_. Default: **true**
 
 This will condense multiple dashes (e.g. `foo---bar`) down to a single dash (`foo-bar`). This is useful to avoid scenarios like `foo & bar` becoming `foo--bar`.
+
+#### MaxLength
+
+Type: _int?_. Default: **null**
+
+This will limit the length of the generated slug to the number of chars given by the parameter.
 
 License
 -------

--- a/src/Slugify.Core/SlugHelper.cs
+++ b/src/Slugify.Core/SlugHelper.cs
@@ -56,6 +56,11 @@ namespace Slugify
                 CollapseDashes(sb);
             }
 
+            if (Config.MaxLength.HasValue)
+            {
+                TrimToMaxLength(sb, Config.MaxLength.Value);
+            }
+
             return sb.ToString();
         }
 
@@ -209,6 +214,14 @@ namespace Slugify
         }
 
         protected static string DeleteCharacters(string str, Regex deniedCharactersRegex) => deniedCharactersRegex.Replace(str, string.Empty);
+
+        protected static void TrimToMaxLength(StringBuilder sb, int maxLength)
+        {
+            if (sb.Length > maxLength)
+            {
+                sb.Remove(maxLength, sb.Length - maxLength);
+            }
+        }
     }
 }
 

--- a/src/Slugify.Core/SlugHelperConfiguration.cs
+++ b/src/Slugify.Core/SlugHelperConfiguration.cs
@@ -37,6 +37,8 @@ namespace Slugify
         }
         public bool CollapseDashes { get; set; } = true;
         public bool TrimWhitespace { get; set; } = true;
+        
+        public int? MaxLength { get; set; }
     }
 }
 

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -418,7 +418,7 @@ namespace Slugify.Tests
         [InlineData(null, "abcdefghijgklmnopqrstuvwxy", "abcdefghijgklmnopqrstuvwxy")]
         [InlineData(8, "abcdefghijgklmnopqrstuvwxy", "abcdefgh")]
         [InlineData(8, "ab c d e fgh", "ab-c-d-e")]
-        [InlineData(7, "ab c d e fgh", "ab-c-d")]
+        [InlineData(7, "ab c d e", "ab-c-d")] 
         [InlineData(8, "ab c d ", "ab-c-d")]
         public void MaxLengthGivenTrimsUnnecessaryChars(int? length, string input, string expected)
         {

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -414,6 +414,21 @@ namespace Slugify.Tests
             Assert.Equal(expected, helper.GenerateSlug(original));
         }
 
+        [Theory]
+        [InlineData(null, "abcdefghijgklmnopqrstuvwxy", "abcdefghijgklmnopqrstuvwxy")]
+        [InlineData(8, "abcdefghijgklmnopqrstuvwxy", "abcdefgh")]
+        [InlineData(8, "ab c d e fgh", "ab-c-d-e")]
+        [InlineData(7, "ab c d e fgh", "ab-c-d")]
+        [InlineData(8, "ab c d ", "ab-c-d")]
+        public void MaxLengthGivenTrimsUnnecessaryChars(int? length, string input, string expected)
+        {
+            var helper = Create(new SlugHelperConfiguration()
+            {
+                MaxLength = length
+            });
+            Assert.Equal(expected, helper.GenerateSlug(input));
+        }
+
         [Fact(Skip = "Is this actually a bug?")]
         public void TurkishEncodingOfI()
         {


### PR DESCRIPTION
Implements #18 

Added Option to Limit Output Slug Length.
Default Value is null to not introduce any breaking Changes into the Library.