### PR TITLE
Adds new option to limit the length of the generated slugs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,3 +209,9 @@ Specifying the `DeniedCharactersRegex` option will disable the character removal
    });
    Console.WriteLine(helper.GenerateSlug("this is an foo example")); // "this-is-an-example"
    ```
+
+### `MaximumLength`
+
+This will limit the length of the generated slug to be a maximum of the number of chars given by the parameter. If the truncation happens in a way that a trailing `-` is left, it will be removed.
+
+- Default value: `null`

--- a/src/Slugify.Core/SlugHelper.cs
+++ b/src/Slugify.Core/SlugHelper.cs
@@ -83,6 +83,16 @@ public class SlugHelper(SlugHelperConfiguration config) : ISlugHelper
             }
         }
 
+        if (Config.MaximumLength.HasValue && sb.Length > Config.MaximumLength.Value)
+        {
+            sb.Remove(Config.MaximumLength.Value, sb.Length - Config.MaximumLength.Value);
+            // Remove trailing dash if it exists
+            if (sb[sb.Length - 1] == '-')
+            {
+                sb.Remove(sb.Length - 1, 1);
+            }
+        }
+
         return sb.ToString();
     }
 

--- a/src/Slugify.Core/SlugHelperConfiguration.cs
+++ b/src/Slugify.Core/SlugHelperConfiguration.cs
@@ -61,5 +61,10 @@ public class SlugHelperConfiguration
     /// </summary>
     public bool TrimWhitespace { get; set; } = true;
 
+    /// <summary>
+    /// Represents the maximum length of the slug. If the slug is longer than this value, it will be truncated.
+    /// </summary>
+    public int? MaximumLength { get; set; }
+
 }
 

--- a/src/Slugify.Core/Slugify.Core.csproj
+++ b/src/Slugify.Core/Slugify.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>Slugify Core</AssemblyTitle>
 
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
 	<LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -11,15 +11,17 @@
 	<NoWarn>IDE0130;SYSLIB1045</NoWarn>
     <PackageId>Slugify.Core</PackageId>
     <PackageTags>URL;Slug;Web;Slugify</PackageTags>
-    <PackageReleaseNotes>5.0.0 - Rewrite using newer language features. Added support for Non-Ascii languages for SlugHelperForNonAsciiLanguages
-4.0.0 - Bug fix relase from 3.0.0
-3.0.0 - Much improved performance and memory usage. Config file renamed. Potentially some breaking changes but none we're aware of
-2.4.0 - NetStandard 2.0 support only
-2.3.0 - ISlugHelper interface added. Thanks @jcharlesworthuk
-2.2.2 - NetStandard 2.0
-2.2.1 - NuGet package updates
-2.2.0 - Minor tweaks
-    </PackageReleaseNotes>
+    <PackageReleaseNotes>
+		5.1.0 - Adds support for MaximumLength to limit the length of the slug. Thanks @ntbm
+		5.0.0 - Rewrite using newer language features. Added support for Non-Ascii languages for SlugHelperForNonAsciiLanguages
+		4.0.0 - Bug fix relase from 3.0.0
+		3.0.0 - Much improved performance and memory usage. Config file renamed. Potentially some breaking changes but none we're aware of
+		2.4.0 - NetStandard 2.0 support only
+		2.3.0 - ISlugHelper interface added. Thanks @jcharlesworthuk
+		2.2.2 - NetStandard 2.0
+		2.2.1 - NuGet package updates
+		2.2.0 - Minor tweaks
+	</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/ctolkien/Slugify</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
     <RepositoryType>git</RepositoryType>

--- a/tests/Slugify.Core.Tests/SlugHelperTests.cs
+++ b/tests/Slugify.Core.Tests/SlugHelperTests.cs
@@ -739,4 +739,19 @@ public class SlugHelperTest
 
         Assert.Equal(expected, helper.GenerateSlug(original));
     }
+
+    [Theory]
+    [InlineData(null, "abcdefghijgklmnopqrstuvwxy", "abcdefghijgklmnopqrstuvwxy")]
+    [InlineData(8, "abcdefghijgklmnopqrstuvwxy", "abcdefgh")]
+    [InlineData(8, "ab c d e fgh", "ab-c-d-e")]
+    [InlineData(7, "ab c d e", "ab-c-d")]
+    [InlineData(8, "ab c d ", "ab-c-d")]
+    public void MaximumLengthGivenTrimsUnnecessaryChars(int? length, string input, string expected)
+    {
+        var helper = Create(new SlugHelperConfiguration()
+        {
+            MaximumLength = length
+        });
+        Assert.Equal(expected, helper.GenerateSlug(input));
+    }
 }


### PR DESCRIPTION
This is a re-implementation of https://github.com/ctolkien/Slugify/pull/50 against the V5 codebase.

Tests have been copypasta'd

Fixes #18 