### PR TITLE
Add configurable support for non-ASCII languages in Slugify

### DIFF
--- a/src/Slugify.Core/SlugHelper.cs
+++ b/src/Slugify.Core/SlugHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Slugify.Core;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -30,9 +31,11 @@ public class SlugHelper(SlugHelperConfiguration config) : ISlugHelper
             throw new ArgumentNullException(nameof(inputString));
         }
 
+        var normalizedInput = config.SupportNonAsciiLanguages
+            ? UnicodeDecoder.UniDecode(inputString)
+            : inputString;
 
-        var normalizedInput = inputString.Normalize(NormalizationForm.FormD);
-
+        normalizedInput = normalizedInput.Normalize(NormalizationForm.FormD);
         normalizedInput = Config.TrimWhitespace ? normalizedInput.Trim() : normalizedInput;
         normalizedInput = Config.ForceLowerCase ? normalizedInput.ToLowerInvariant() : normalizedInput;
 
@@ -97,4 +100,3 @@ public class SlugHelper(SlugHelperConfiguration config) : ISlugHelper
     }
 
 }
-

--- a/src/Slugify.Core/SlugHelperConfiguration.cs
+++ b/src/Slugify.Core/SlugHelperConfiguration.cs
@@ -66,5 +66,10 @@ public class SlugHelperConfiguration
     /// </summary>
     public int? MaximumLength { get; set; }
 
+    /// <summary>
+    /// Enable non-ASCII languages support. Defaults to false
+    /// </summary>
+    public bool SupportNonAsciiLanguages { get; set; }
+
 }
 

--- a/src/Slugify.Core/SlugHelperForNonAsciiLanguages.cs
+++ b/src/Slugify.Core/SlugHelperForNonAsciiLanguages.cs
@@ -1,10 +1,12 @@
 ﻿using Slugify.Core;
+using System;
 
 namespace Slugify;
 
 /// <summary>
 /// This is a <see cref="SlugHelper"/> that is designed to work with non-ASCII languages.
 /// </summary>
+[Obsolete("Use SlugHelper with SupportNonAsciiLanguages option instead")]
 public class SlugHelperForNonAsciiLanguages : SlugHelper
 {
     public SlugHelperForNonAsciiLanguages()

--- a/src/Slugify.Core/Slugify.Core.csproj
+++ b/src/Slugify.Core/Slugify.Core.csproj
@@ -40,6 +40,8 @@ With default settings, you will get an hyphenized, lowercase, alphanumeric versi
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
+    <AssemblyVersion>5.1.1.1</AssemblyVersion>
+    <FileVersion>5.1.1.1</FileVersion>
   </PropertyGroup>
 
   <!-- Deterministic builds -->

--- a/tests/Slugify.Core.Benchmarks/Program.cs
+++ b/tests/Slugify.Core.Benchmarks/Program.cs
@@ -82,7 +82,11 @@ public partial class SlugifyBenchmarks
     [Benchmark]
     public void NonAscii()
     {
-        var helper = new SlugHelperForNonAsciiLanguages();
+        var helper = new SlugHelper(new SlugHelperConfiguration()
+        {
+            SupportNonAsciiLanguages = true
+        });
+
         for (var i = 0; i < _textList.Count; i++)
         {
             helper.GenerateSlug(_textList[i]);

--- a/tests/Slugify.Core.Benchmarks/Slugify.Core.Benchmarks.csproj
+++ b/tests/Slugify.Core.Benchmarks/Slugify.Core.Benchmarks.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net8</TargetFramework>
     <IsPackable>false</IsPackable>
 	<NoWarn>SYSLIB1045</NoWarn>
+	<AssemblyVersion>1.0.0.1</AssemblyVersion>
+	<FileVersion>1.0.0.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Slugify.Core.Tests/Slugify.Core.Tests.csproj
+++ b/tests/Slugify.Core.Tests/Slugify.Core.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8</TargetFramework>
     <IsPackable>false</IsPackable>
 	<NoWarn>xUnit1045;xUnit1004;IDE0130;SYSLIB1045;CA1859</NoWarn>
+	<AssemblyVersion>1.0.0.1</AssemblyVersion>
+	<FileVersion>1.0.0.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Introduced a `SupportNonAsciiLanguages` option in `SlugHelperConfiguration` to enable handling of non-ASCII characters. Updated `SlugHelper` to use this option, replacing the now-obsolete `SlugHelperForNonAsciiLanguages` class.

Refactored tests and benchmarks to use the new configuration, adding comprehensive test cases for various languages and edge cases. Removed redundant methods and tests tied to the old approach.

Updated project files to reflect version changes, signaling the introduction of this streamlined and unified feature.

Related Work Items: #157